### PR TITLE
Add test target for simple configuration checks

### DIFF
--- a/scitran.py
+++ b/scitran.py
@@ -495,6 +495,16 @@ def test(args):
         underscore = error.rfind("_") + 1
         exit(int(error[underscore:]))
 
+        # TODO: gather more information about the failure cause
+
+    # fig run creates special containers with naming pattern of '/prefix_container_run_int', e.g. /local_nginx_run_1
+    # delete these immediately to prevent accumulation of testing containers
+    docker_client = docker.Client(base_url=config['docker_url'])
+    for container in docker_client.containers(all=True):
+        if ('/%s_nginx_run_1' % fig_prefix) in container['Names']:
+            docker_client.stop(container=container['Id'])
+            docker_client.remove_container(container=container['Id'], v=True)
+
 def inspect(args):
     pass
 

--- a/scitran.py
+++ b/scitran.py
@@ -480,7 +480,7 @@ def test(args):
     config = read_config(CONFIG_FILE)
     fig_prefix = config.get('fig_prefix')
     try:
-        sh.Command("bin/fig")("-f", "containers/fig.yml", "-p", fig_prefix, "run", "nginx", "nginx", "-t", _out=process_output, _err=process_output)
+        sh.Command("bin/fig")("-f", "containers/fig.yml", "-p", fig_prefix, "run", '--no-deps', "nginx", "nginx", "-t", _out=process_output, _err=process_output)
 
         # TODO: add more checks here...
 

--- a/scitran.py
+++ b/scitran.py
@@ -480,7 +480,7 @@ def test(args):
     config = read_config(CONFIG_FILE)
     fig_prefix = config.get('fig_prefix')
     try:
-        sh.Command("bin/fig")("-f", "containers/fig.yml", "-p", fig_prefix, "run", '--no-deps', "nginx", "nginx", "-t", _out=process_output, _err=process_output)
+        sh.Command("bin/fig")("-f", "containers/fig.yml", "-p", fig_prefix, "run", "nginx", "nginx", "-t", _out=process_output, _err=process_output)
 
         # TODO: add more checks here...
 

--- a/scitran.py
+++ b/scitran.py
@@ -477,9 +477,10 @@ def stop(args):
 
 def test(args):
     """Run various pre-launch tests"""
-
+    config = read_config(CONFIG_FILE)
+    fig_prefix = config.get('fig_prefix')
     try:
-        sh.Command("bin/fig")("-f", "containers/fig.yml", "-p", "scitran", "run", "nginx", "nginx", "-t", _out=process_output, _err=process_output)
+        sh.Command("bin/fig")("-f", "containers/fig.yml", "-p", fig_prefix, "run", "nginx", "nginx", "-t", _out=process_output, _err=process_output)
 
         # TODO: add more checks here...
 


### PR DESCRIPTION
Added a simple target to test scitran configuration before launching.

This will prevent us from, say, having no idea when nginx fails to launch.