### PR TITLE
Move all keys to persistent folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,16 +7,14 @@
 
 # Generated and distribution files
 /venv
-/*.pem
-/api/key+cert.pem
+/api/*.pem
 /api/production.ini
 /api/bootstrap.json
 /containers/*.tar*
 /containers/fig.yml
 /config.toml
 /persistent/
-/nginx/key+cert.pem
-/nginx/client-*.ca.pem
+/nginx/*.pem
 
 # Distribution
 /*.tar

--- a/README.md
+++ b/README.md
@@ -57,3 +57,12 @@ Finally, boot your local instance:
 ```
 sudo bash -c "source scitran/venv/bin/activate && sudo scitran/scitran.py start"
 ```
+
+Upgrading from pre 0.2.2:
+Stop your instance, move `key+cert.pem` to `persistet/keys/base-key+cert.pem`, and then restart your instance.
+
+```
+sudo bash -c "source scitran/venv/bin/activate && sudo scitran/scitran.py stop"
+mv scitran/key+cert.pem scitran/persistent/keys/base-key+cert.pem
+sudo bash -c "source scitran/venv/bin/activate && sudo scitran/scitran.py start"
+```

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -19,8 +19,8 @@ http {
     gzip_proxied any;
     gzip_types text/plain text/css text/xml text/javascript application/json application/x-javascript application/xml application/xml+rss;
 
-    ssl_certificate /etc/nginx/key+cert.pem;
-    ssl_certificate_key /etc/nginx/key+cert.pem;
+    ssl_certificate /etc/nginx/base-key+cert.pem;
+    ssl_certificate_key /etc/nginx/base-key+cert.pem;
     ssl_prefer_server_ciphers on;
     ssl_session_cache shared:SSL:1m;
     ssl_protocols TLSv1 TLSv1.1 TLSv1.2;

--- a/nginx/nginx.default.conf
+++ b/nginx/nginx.default.conf
@@ -19,8 +19,8 @@ http {
     gzip_proxied any;
     gzip_types text/plain text/css text/xml text/javascript application/json application/x-javascript application/xml application/xml+rss;
 
-    ssl_certificate /etc/nginx/key+cert.pem;
-    ssl_certificate_key /etc/nginx/key+cert.pem;
+    ssl_certificate /etc/nginx/base-key+cert.pem;
+    ssl_certificate_key /etc/nginx/base-key+cert.pem;
     ssl_prefer_server_ciphers on;
     ssl_session_cache shared:SSL:1m;
     ssl_protocols TLSv1 TLSv1.1 TLSv1.2;

--- a/scitran.py
+++ b/scitran.py
@@ -213,7 +213,7 @@ def create_client_cert(drone_name):
     drone_key =      os.path.join('persistent', 'keys', 'client-%s-key.pem'      % drone_name)
     drone_cert =     os.path.join('persistent', 'keys', 'client-%s-cert.pem'     % drone_name)
     drone_csr =      os.path.join('persistent', 'keys', 'client-%s.csr'          % drone_name)
-    drone_combined = os.path.join('persistent', 'keys', 'client-%s_key+cert.pem' % drone_name)
+    drone_combined = os.path.join('persistent', 'keys', 'client-%s-key+cert.pem' % drone_name)
     sh.openssl('genrsa', '-out', drone_key, '2048')
     sh.openssl('req', '-new', '-key', drone_key, '-out', drone_csr, _in=input_)
     if not os.path.exists(ROOT_SRL_FILE):

--- a/scitran.py
+++ b/scitran.py
@@ -24,14 +24,17 @@ os.chdir(HERE)
 
 # preflight
 CONFIG_FILE = 'config.toml'
-KEY_CERT_COMBINED_FILE = 'key+cert.pem'
-KEY_FILE = 'key.pem'
-CERT_FILE = 'cert.pem'
 
-ROOT_CERT_COMBINED_FILE = 'rootCA_key+cert.pem'
-ROOT_KEY_FILE = 'rootCA_key.pem'
-ROOT_CERT_FILE = 'rootCA_cert.pem'
-ROOT_SRL_FILE = 'rootCA_cert.srl'
+KEYS_FOLDER = os.path.join('persistent', 'keys')
+
+KEY_CERT_COMBINED_FILE =   os.path.join(KEYS_FOLDER, 'base-key+cert.pem')
+KEY_FILE =                 os.path.join(KEYS_FOLDER, 'base-key.pem')
+CERT_FILE =                os.path.join(KEYS_FOLDER, 'base-cert.pem')
+
+ROOT_CERT_COMBINED_FILE  = os.path.join(KEYS_FOLDER, 'rootCA-key+cert.pem')
+ROOT_KEY_FILE =            os.path.join(KEYS_FOLDER, 'rootCA-key.pem')
+ROOT_CERT_FILE =           os.path.join(KEYS_FOLDER, 'rootCA-cert.pem')
+ROOT_SRL_FILE =            os.path.join(KEYS_FOLDER, 'rootCA-cert.srl')
 
 FIG_IN = os.path.join("scripts", "templates", "fig.yml")
 FIG_OUT = os.path.join("containers", "fig.yml")
@@ -207,9 +210,9 @@ def create_client_cert(drone_name):
     # each of the signed certs MUST have a complete DN, including common name
     # however, the common name does not need to match... wait...i thought nginx did hostname matching
     input_ = ['\n'] * 5 + ['localhost\n'] + (['\n'] * 30)
-    drone_key = '%s_key.pem' % drone_name
-    drone_cert = '%s_cert.pem' % drone_name
-    drone_csr = '%s.csr' % drone_name
+    drone_key = 'keys/client-%s-key.pem' % drone_name
+    drone_cert = 'keys/client-%s-cert.pem' % drone_name
+    drone_csr = 'keys/client-%s.csr' % drone_name
     drone_combined = '%s_key+cert.pem' % drone_name
     sh.openssl('genrsa', '-out', drone_key, '2048')
     sh.openssl('req', '-new', '-key', drone_key, '-out', drone_csr, _in=input_)
@@ -227,10 +230,16 @@ def create_client_cert(drone_name):
     combined.write(key + cert)
     combined.close()
 
+    # After signing, the CSR is useless
+    os.remove(drone_csr)
+
 
 def create_self_signed_cert():
     """Create selfsigned key+cert.pem."""
     print "Generating certificate with OpenSSL..."
+
+    # Folder to hold all client certificates
+    if not os.path.exists(KEYS_FOLDER): os.makedirs(KEYS_FOLDER)
 
     # OpenSSL will ask you some arbitrary set of questions, all of which are irrelevat for self-signed certificates.
     # This feeds a large set of newlines in an attempt to brute-force ignore its prompts.
@@ -434,14 +443,11 @@ def start(args):
     # copy key+cert.pem into locations that will be bind mounted to the containers
     print 'Copying key+cert.pem into api and nginx bind mount locations'
     combinedCert = open(KEY_CERT_COMBINED_FILE).read()
-    open(os.path.join("api", KEY_CERT_COMBINED_FILE), "w").write(combinedCert)
-    open(os.path.join("nginx", KEY_CERT_COMBINED_FILE), "w").write(combinedCert)
+    shutil.copy2(KEY_CERT_COMBINED_FILE, 'api')
+    shutil.copy2(KEY_CERT_COMBINED_FILE, 'nginx')
 
     # also copy our created root CA certificate in place
-    combinedCA = open(ROOT_CERT_COMBINED_FILE).read()
-    with open(os.path.join("nginx", ROOT_CERT_COMBINED_FILE), "w") as nginx_root_ca:
-        nginx_root_ca.write(combinedCA)
-        print 'Copied rootCA_key+cert.pem into nginx bind mount location'
+    shutil.copy2(ROOT_CERT_COMBINED_FILE, 'nginx')
 
     # Detect if cluster is new (has never been started before)
     newCluster = not os.path.isfile(os.path.join('persistent', 'mongo', 'mongod.lock'))

--- a/scitran.py
+++ b/scitran.py
@@ -210,10 +210,10 @@ def create_client_cert(drone_name):
     # each of the signed certs MUST have a complete DN, including common name
     # however, the common name does not need to match... wait...i thought nginx did hostname matching
     input_ = ['\n'] * 5 + ['localhost\n'] + (['\n'] * 30)
-    drone_key = 'keys/client-%s-key.pem' % drone_name
-    drone_cert = 'keys/client-%s-cert.pem' % drone_name
-    drone_csr = 'keys/client-%s.csr' % drone_name
-    drone_combined = '%s_key+cert.pem' % drone_name
+    drone_key =      os.path.join('persistent', 'keys', 'client-%s-key.pem'      % drone_name)
+    drone_cert =     os.path.join('persistent', 'keys', 'client-%s-cert.pem'     % drone_name)
+    drone_csr =      os.path.join('persistent', 'keys', 'client-%s.csr'          % drone_name)
+    drone_combined = os.path.join('persistent', 'keys', 'client-%s_key+cert.pem' % drone_name)
     sh.openssl('genrsa', '-out', drone_key, '2048')
     sh.openssl('req', '-new', '-key', drone_key, '-out', drone_csr, _in=input_)
     if not os.path.exists(ROOT_SRL_FILE):


### PR DESCRIPTION
We had several problems with our current SSL key usage:

* Tons of stateful files were landing outside the persistent folder where they do not belong
* Naming was not consistent amongst keys, causing confusion
* Usage of the `add_drone` target was only going to compound this

Keys now land in the unsurprisingly named `persistent/keys/` directory.