### PR TITLE
Disable resp buffering and increase buff size

### DIFF
--- a/templates/nginx/nginx.conf
+++ b/templates/nginx/nginx.conf
@@ -53,6 +53,8 @@ http {
 
 		location /api {
 			uwsgi_pass {{uwsgi.uri}};
+			uwsgi_buffering off;
+			uwsgi_buffers 8 1M;
 			uwsgi_request_buffering off;
 			include uwsgi_params;
 			proxy_set_header Host $host;
@@ -77,6 +79,8 @@ http {
 
 		location /api {
 			uwsgi_pass {{uwsgi.uri}};
+			uwsgi_buffering off;
+			uwsgi_buffers 8 1M;
 			uwsgi_request_buffering off;
 			include uwsgi_params;
 			uwsgi_param SSL_CLIENT_VERIFY $ssl_client_verify;


### PR DESCRIPTION
This was required to bump the download chunk size up to 1MB and get reliable results.