### PR TITLE
Auth changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Separate scitran folders are recommended!
 
 ## Migrating
 
-If your [`config.toml`]((https://github.com/scitran/scitran/blob/master/templates/config.toml)) is out of date, `live.sh` will decline to run.<br>
+If your [`config.toml`](templates/config.toml) is out of date, `live.sh` will decline to run.<br>
 Usually, updating can be easily achieved by adding a new config key.
 
 Check which version you're at, and read the neccesary sections:
@@ -114,11 +114,11 @@ This version removes the `ports.machine` key.<br>
 Due to the changes we're making to authentication, this client-certificate port will no longer be used.
 
 This version also adds the `auth.shared_secret` key.<br>
-See our section about [configuring auth secret](https://github.com/scitran/scitran#serving-valid-ssl-keys) to set up.
+See our section about [configuring auth secret](#setting-your-machine-auth-secret) to set up.
 
 #### To 1.1
 
 Since config v1, we've added a `nginx.user` key.<br>
 This will allow production users running as root to configure permissions for nginx workers.
 
-See [our default `config.toml`](https://github.com/scitran/scitran/blob/master/templates/config.toml) and copy the nginx section to upgrade.
+See [our default `config.toml`](templates/config.toml) and copy the nginx section to upgrade.

--- a/README.md
+++ b/README.md
@@ -89,23 +89,6 @@ For example, to set up with google:
 You can enter your key and endpoints in config.toml under the `auth` section.<br>
 Right now, only a few providers have been tested. [Ask us](https://github.com/scitran/scitran/issues/new) if you have problems!
 
-### Configuring 'drone' devices
-
-Scitran currently supports authenticating with client SSL certificates to bypass OAuth for automated access.
-In the future it may be used for adding a [reaper](https://github.com/scitran/reaper) to automatically acquire MRI data.
-
-This is kept on a different port (default 8444) for compatibility reasons and to allow separate network management.
-The web UI is not accessible over this port.
-
-In `persistent/keys` you'll find `rootCA-key.pem` and `rootCA-cert.pem`, which are used for signing drones.
-Unlike the SSL cert, it doesn't matter that this one is self-signed.
-
-To add a drone, run `./live.sh add-drone [drone name]`.<br>
-Signed keys will be saved to  `persistent/keys`.
-
-We are actively discussing this feature, and it may change in the future!
-
-
 ### Note about virtual installs
 
 Finally, note that if you're trying out scitran with vagrant, the database is not stored on the host.<br>

--- a/README.md
+++ b/README.md
@@ -51,6 +51,21 @@ If you're looking to use scitran in production, there are a few things to prepar
 You'll find a few files in `persistent/keys`. Notably, `base-key+cert.pem` is used to serve scitran.<br>
 Due to our current architecture, SSL is mandatory. Switch this key for one of your own as desired.
 
+### Setting your machine auth secret
+
+Automated requests (such as from a [reaper](https://github.com/scitran/reaper)) will need a shared secret.<br>
+Anyone who knows this secret can make API requests, so you should protect it accordingly.<br>
+
+We recommend using makepasswd to generate a suitable secret:
+
+```bash
+sudo apt-get install -y makepasswd
+
+makepasswd --minchars=20 --maxchars=30
+```
+
+Save this value in your `config.toml` file as `auth.shared_secret`.
+
 ### Setting up your own OAuth provider
 
 Scitran ships with a google OAuth key that will allow you to authenticate to a local instance.<br>
@@ -105,10 +120,18 @@ Separate scitran folders are recommended!
 
 ## Migrating
 
-If your `config.toml` is out of date, `live.sh` will decline to run.<br>
+If your [`config.toml`]((https://github.com/scitran/scitran/blob/master/templates/config.toml)) is out of date, `live.sh` will decline to run.<br>
 Usually, updating can be easily achieved by adding a new config key.
 
 Check which version you're at, and read the neccesary sections:
+
+#### To 1.2
+
+This version removes the `ports.machine` key.<br>
+Due to the changes we're making to authentication, this client-certificate port will no longer be used.
+
+This version also adds the `auth.shared_secret` key.<br>
+See our section about [configuring auth secret](https://github.com/scitran/scitran#serving-valid-ssl-keys) to set up.
 
 #### To 1.1
 

--- a/scripts/check-version.py
+++ b/scripts/check-version.py
@@ -6,27 +6,30 @@ import pystache
 import toml
 import re
 
-expectedVersion = toml.loads(open('templates/config.toml', 'r').read())['flywheel']['version']
+filename = sys.argv[1]
+mapping = toml.loads(open(filename, 'r').read())
 
-mapP = sys.argv[1]
-mapping = toml.loads(open(mapP, 'r').read())
+template = toml.loads(open('templates/config.toml', 'r').read())
 
+# Check config secret
+if 'auth' in mapping and 'shared_secret' in mapping['auth']:
+	if mapping['auth']['shared_secret'] == template['auth']['shared_secret']:
+
+		print >> sys.stderr, '\nWarning: Your shared secret has not been changed from its default.\nYour system will be insecure until you change auth.shared_secret in config.toml.\n'
+
+
+# Check config version
 if 'flywheel' in mapping and 'version' in mapping['flywheel'] and ( isinstance( mapping['flywheel']['version'], int ) or isinstance( mapping['flywheel']['version'], float )):
-	version = mapping['flywheel']['version']
 
-	if version > expectedVersion:
+	version  = mapping['flywheel']['version']
+	expected = template['flywheel']['version']
+
+	if version > expected:
 		# Config is too new; proceed with caution
-		print >> sys.stderr, ''
-		print >> sys.stderr, 'Your flywheel.version key in config.toml is ' + str(version) + ', expected ' + str(expectedVersion) + '.'
-		print >> sys.stderr, 'Unexpected behaviour may occur!'
-		print >> sys.stderr, ''
-	elif version < expectedVersion:
+		print >> sys.stderr, '\nYour flywheel.version key in config.toml is ' + str(version) + ', expected ' + str(expected) + '.\nUnexpected behaviour may occur!\n'
+	elif version < expected:
 		# Config is too new; assume broken
-		print >> sys.stderr, ''
-		print >> sys.stderr, 'Your flywheel.version key in config.toml is ' + str(version) + ', expected ' + str(expectedVersion) + '.'
-		print >> sys.stderr, 'See the readme for migration instructions:'
-		print >> sys.stderr, ''
-		print >> sys.stderr, 'https://github.com/scitran/scitran#migrating'
+		print >> sys.stderr, '\nYour flywheel.version key in config.toml is ' + str(version) + ', expected ' + str(expected) + '.\nSee the readme for migration instructions:\n\nhttps://github.com/scitran/scitran#migrating'
 		sys.exit(2)
 
 else:

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -303,20 +303,6 @@ function EnsureCode() {(
 )}
 
 function EnsureClientCertificates() {(
-	# Ensure root CA ready
-	test -f $ROOT_CERT_COMBINED_FILE || (
-		# Create a root CA key
-		openssl genrsa -out $ROOT_KEY_FILE 2048
-
-		# Create a root CA cert
-		openssl req -x509 -new -nodes -subj "/C=US/ST=example/L=example/O=example/CN=example" -key $ROOT_KEY_FILE -days 999 -out $ROOT_CERT_FILE
-
-		# Combine for nginx
-		cat $ROOT_KEY_FILE $ROOT_CERT_FILE > $ROOT_CERT_COMBINED_FILE
-
-		bb-log-info "Generated CA certificate"
-	)
-
 	# Ensure server cert for SSL
 	test -f $KEY_CERT_COMBINED_FILE || (
 		# Generate individual files
@@ -327,11 +313,6 @@ function EnsureClientCertificates() {(
 
 		bb-log-info "Generated server certificate"
 	)
-
-	# Combine the ca-certificates bundle with out our trusted CA certificate
-	# This is a hackaround for having to give nginx a single CA certs package for client cert auth.
-	# Which is itself a hackaround for making nginx more compatible with various SSL client auth libraries (eg, golang).
-	cat /etc/ssl/certs/ca-certificates.crt $ROOT_CERT_FILE > $CA_CERTS_COMBINED_FILE
 )}
 
 #

--- a/templates/config.toml
+++ b/templates/config.toml
@@ -2,7 +2,7 @@
 [flywheel]
 	# Used to identify config file versions and prevent flywheel from running without important keys.
 	# This is only changed when breaking changes are made and does not reflect product version.
-	version = 1.1
+	version = 1.2
 
 [site]
 	# Human friendly site name!
@@ -31,10 +31,6 @@
 	# In production, you likely want to set this to 443.
 	web = 8443
 
-	# A separate port that mandates SSL client certificate authentication.
-	# Only uses for automated access such as a reaper instance.
-	machine = 8444
-
 [central]
 	# Is this instance registered with central?
 	registered = false
@@ -43,11 +39,17 @@
 	url = "https://sdmc.scitran.io/api"
 
 [auth]
+	# Shared secret used for machine authentication.
+	# Anyone who knows this string can make API calls.
+	shared_secret   = "change-me"
+
+	# oAuth provider type for user authentication
 	provider        = "Google"
 
 	# Default client ID for development environments
 	client_id       = "1052740023071-n20pk8h5uepdua3r8971pc6jrf25lvee.apps.googleusercontent.com"
 
+	# Endpoints for oAuth provider
 	id_endpoint     = "https://www.googleapis.com/plus/v1/people/me/openIdConnect"
 	auth_endpoint   = "https://accounts.google.com/o/oauth2/auth"
 	verify_endpoint = "https://www.googleapis.com/oauth2/v1/tokeninfo"

--- a/templates/nginx/nginx.conf
+++ b/templates/nginx/nginx.conf
@@ -73,31 +73,4 @@ http {
 			}
 		}
 	}
-
-	server {
-		listen {{ports.machine}} ssl;
-
-		ssl_client_certificate ../../keys/ca-certificates+scitranCA.crt;
-		ssl_verify_client on;
-		ssl_verify_depth 3;
-
-		location /api {
-			uwsgi_pass {{uwsgi.uri}};
-			uwsgi_buffering off;
-			uwsgi_buffers 8 1M;
-			uwsgi_request_buffering off;
-			include uwsgi_params;
-			uwsgi_param SSL_CLIENT_VERIFY $ssl_client_verify;
-			proxy_set_header Host $host;
-			client_max_body_size 50g;
-			add_header Access-Control-Allow-Origin $http_origin always;
-			if ($request_method = OPTIONS) {
-				add_header Access-Control-Allow-Origin $http_origin always;
-				add_header Access-Control-Allow-Methods 'GET, HEAD, POST, PUT, DELETE, OPTIONS';
-				add_header Access-Control-Allow-Headers 'Authorization, Content-Type, Content-MD5';
-				add_header Access-Control-Max-Age 151200;
-				return 204;
-			}
-		}
-	}
 }

--- a/templates/uwsgi.config.ini
+++ b/templates/uwsgi.config.ini
@@ -17,4 +17,4 @@ pidfile = {{pDir}}/uwsgi.pid
 ; I guess this is relative to chdir
 master-fifo = ../../{{pDir}}/uwsgi.fifo
 ; Hackaround using old config flags, will replace with env variables
-pyargv = --site_id {{site.id}} --site_name {{site.name}} --api_uri 'https://{{site.domain}}:8080/api', --db_uri {{mongo.uri}} --data_path ../../{{data.location}} --apps_path ../../code/apps --ssl_cert ../../{{gDir}}/keys/base-key+cert.pem {{#central.registered}} {{central.url}} {{/central.registered}} {{#site.demo}} --demo {{/site.demo}} {{#site.insecure}} --insecure {{/site.insecure}} --oauth2_id_endpoint {{auth.id_endpoint}}
+pyargv = --site_id {{site.id}} --site_name {{site.name}} --api_uri 'https://{{site.domain}}:8080/api', --db_uri {{mongo.uri}} --data_path ../../{{data.location}} --apps_path ../../code/apps --ssl_cert ../../{{gDir}}/keys/base-key+cert.pem {{#central.registered}} {{central.url}} {{/central.registered}} {{#site.demo}} --demo {{/site.demo}} {{#site.insecure}} --insecure {{/site.insecure}} --oauth2_id_endpoint {{auth.id_endpoint}} --secret {{auth.shared_secret}}

--- a/templates/uwsgi.config.ini
+++ b/templates/uwsgi.config.ini
@@ -17,4 +17,4 @@ pidfile = {{pDir}}/uwsgi.pid
 ; I guess this is relative to chdir
 master-fifo = ../../{{pDir}}/uwsgi.fifo
 ; Hackaround using old config flags, will replace with env variables
-pyargv = --site_id {{site.id}} --site_name {{site.name}} --api_uri 'https://{{site.domain}}:8080/api', --db_uri {{mongo.uri}} --data_path ../../{{data.location}} --apps_path ../../code/apps --ssl_cert ../../{{gDir}}/keys/base-key+cert.pem {{#central.registered}} {{central.url}} {{/central.registered}} {{#site.demo}} --demo {{/site.demo}} {{#site.insecure}} --insecure {{/site.insecure}} --oauth2_id_endpoint {{auth.id_endpoint}} --secret {{auth.shared_secret}}
+pyargv = --site_id {{site.id}} --site_name {{site.name}} --api_uri 'https://{{site.domain}}:8080/api', --db_uri {{mongo.uri}} --data_path ../../{{data.location}} --apps_path ../../code/apps --ssl_cert ../../{{gDir}}/keys/base-key+cert.pem {{#central.registered}} {{central.url}} {{/central.registered}} {{#site.demo}} --demo {{/site.demo}} {{#site.insecure}} --insecure {{/site.insecure}} --oauth2_id_endpoint {{auth.id_endpoint}} --drone_secret {{auth.shared_secret}}


### PR DESCRIPTION
From our notes regarding placeholder device authentication:

* Eliminating the drone port, rootCA keys, and drone keys.
* Automated authorization will be via a single shared secret stored in config.toml.
* Automated calls must set their user agent header to 'SciTran Drone NAME', where NAME can be anything (possibly ‘reaper’ or ‘engine’).
* Automated calls must send the shared secret in the X-SciTran-Auth header.
* Drone listing in the database will be completely ignored and have no effect.
* All drones will operate at the same permission level and have the same capabilities.

I believe this to be everything necessary on the infrastructure side to prepare for this feature.
This should be ready to merge.