### PR TITLE
Target reconfiguration for production-friendly usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,6 @@ Finish your install with:
 
 This will prepare a user account and an example dataset to try out.
 
-Right now, you will need to edit [templates/bootstrap.json](templates/bootstrap.json) with your name and email address, before configuring. In the future, this will be [handled for you](https://github.com/scitran/scitran/issues/37).
-
 ### Vagrant
 
 If you're not using Linux, you'll need to use [Vagrant](https://www.vagrantup.com).<br>

--- a/README.md
+++ b/README.md
@@ -13,25 +13,40 @@ Do Research. Extract Opportunity.
 You'll need [Python 2.7](https://www.python.org) and [Git](https://git-scm.com).<br>
 Scitran runs on Ubuntu 64-bit, or inside a virtual environment.
 
-Right now, you will need to edit [templates/bootstrap.json](templates/bootstrap.json) with your name and email address, before launching. In the future, this will be [handled for you](https://github.com/scitran/scitran/issues/37).
-
 ```bash
 git clone https://github.com/scitran/scitran.git && cd scitran
 
-./live.sh
+./live.sh setup
 ```
 
-If you're not using Linux, the command is the same but inside [Vagrant](https://www.vagrantup.com):
+This will install everything scitran needs and generate things you need, such as a config file.<br>
+If desired, you can edit your config file now, or you can come back later. Check out [configuring](#configuring) for more info.
+
+Finish your install with:
 
 ```bash
-vagrant up
-
-vagrant ssh -c /scitran/live.sh
+./live.sh configure
 ```
 
-In either case, you can now check out your local instance at [https://localhost:8443](https://localhost:8443)!
+This will prepare a user account and an example dataset to try out.
 
-Your first run of `live.sh` will take quite awhile to install; subsequent runs will be much faster.
+Right now, you will need to edit [templates/bootstrap.json](templates/bootstrap.json) with your name and email address, before configuring. In the future, this will be [handled for you](https://github.com/scitran/scitran/issues/37).
+
+### Vagrant
+
+If you're not using Linux, you'll need to use [Vagrant](https://www.vagrantup.com).<br>
+From the scitran folder, simply run `vagrant up && vagrant ssh`, then use the same commands above.
+
+## Running
+
+Once you have setup and configured scitran, running is as easy as:
+
+```bash
+./live.sh run
+```
+
+Check out your new local instance at [https://localhost:8443](https://localhost:8443)!
+
 This script will start everything it needs (nginx, mongo, uwsgi) and run them until you quit (Control-C).
 
 ### Managing processes

--- a/live.sh
+++ b/live.sh
@@ -17,9 +17,14 @@
 	source scripts/2-run.sh
 	source scripts/3-targets.sh
 
-	# Run default or specific target
+	function Usage() {
+		echo "Usage: $0 {setup|run|venv|api|template|ci|release|update|secret|reset-db}" 1>&2;
+		exit 1
+	}
+
+	# Choose target
 	if [ -z "$1" ] ; then
-		Launch
+		Usage
 	else
 		case "$1" in
 
@@ -28,6 +33,9 @@
 				Setup
 				Install
 				Configure ;;
+
+			run)
+				Launch ;;
 
 			# Run a command in the venv
 			venv)
@@ -75,10 +83,7 @@
 
 			# Print usage
 			*)
-				echo "Usage: $0 {setup|venv|api|template|ci|release|update|secret|reset-db}" 1>&2;
-				echo "Run without args to launch!" 1>&2;
-				exit 1
-			;;
+				Usage ;;
 		esac
 
 	fi

--- a/live.sh
+++ b/live.sh
@@ -30,12 +30,13 @@
 
 			# Prepare everything for launch, but don't run
 			setup)
-				Setup
-				Install
-				Configure ;;
+				SetupTarget ;;
+
+			configure)
+				ConfigureTarget ;;
 
 			run)
-				Launch ;;
+				RunTarget ;;
 
 			# Run a command in the venv
 			venv)
@@ -62,7 +63,7 @@
 
 			# Run everything desired for CI
 			ci)
-				CI ;;
+				CiTarget ;;
 
 			# Create release tarball
 			release)

--- a/scripts/0-setup.sh
+++ b/scripts/0-setup.sh
@@ -122,7 +122,12 @@ function LoadConfig() {
 function EnsureConfig() {
 
 	test -f config.toml || (
-		cp templates/config.toml config.toml
+		# Generate a shared secret
+		secret=`uuidgen --random /dev/random | sed 's/-//g'`
+
+		# Set shared secret while copying template
+		cat templates/config.toml | sed 's/"change-me"/"'$secret'"/g' > config.toml
+
 		bb-log-info "Generated default config file"
 	)
 

--- a/scripts/2-run.sh
+++ b/scripts/2-run.sh
@@ -36,7 +36,7 @@ function StartReflex() {
 	bb-log-info "Reflex launched with $reflexPID"
 
 	# Hope that infra is online
-	bb-log-info "Waiting for infrastructre to be ready for bootstrap..."
+	bb-log-info "Waiting for infrastructure to be ready for bootstrap..."
 	sleep $waitSeconds
 }
 

--- a/scripts/2-run.sh
+++ b/scripts/2-run.sh
@@ -46,6 +46,56 @@ function StopReflex() {
 	sleep $waitSeconds
 }
 
+# Takes bootstrap file location as param, relative to code/api folder.
+function BootStrapUsers() {(
+	bb-log-info "Loading initial users..."
+
+	# This ain't uwsgi; chdir manually in this subshell
+	cd code/api
+
+	# Run
+	set +e
+
+	# Load user(s)
+	./bootstrap.py dbinit -j $1 "${_mongo_uri}"
+	result=$?
+
+	# Shut down reflex, if bootstrapping failed exit.
+	if [ $result -ne 0 ]; then
+		bb-log-info "Bootstrapping users failed. Cleaning up..."
+		StopReflex
+		exit $result;
+	fi
+)}
+
+function BootStrapData() {(
+	# HACKAROUND: 'bootstrap sort' will *DELETE* data... make a copy :(
+	bb-log-info "Making of copy of the example dataset..."
+	temp="$( bb-tmp-dir )"
+	cp -r ${_folder_testdata}/* $temp
+
+	bb-log-info "Loading example dataset..."
+
+	# This ain't uwsgi; chdir manually in this subshell
+	cd code/api
+
+	# Run
+	set +e
+
+	# Load data
+	# TODO: change to uri
+	./bootstrap.py sort -q mongodb://localhost:${_mongo_port}/scitran $temp ../../persistent/data
+	result=$?
+
+	rm -rf $temp
+
+	if [ $result -ne 0 ]; then
+		bb-log-info "Bootstrapping data failed. Cleaning up..."
+		StopReflex
+		exit $result;
+	fi
+)}
+
 # Add some initial db state if none exists.
 # Should be used before mongo has ever been launched (via Reflex() or otherwise)
 # Hackaround: duplicates Reflex()
@@ -54,52 +104,14 @@ function EnsureBootstrapData() {(
 
 	# Test if mongo has ever been launched before
 	test -f persistent/mongo/mongod.lock || (
-
-		# HACKAROUND: 'bootstrap sort' will *DELETE* data... make a copy :(
-		bb-log-info "Making of copy of the example dataset..."
-		temp="$( bb-tmp-dir )"
-		cp -r ${_folder_testdata}/* $temp
-
 		bb-log-info "Preparing infrastructre for bootstrap..."
 		StartReflex
 
-		# Bootstrap
-		bb-log-info "Loading initial users..."
+		BootStrapUsers ../../${_folder_templates}/bootstrap.json
+		BootStrapData
 
-		# This ain't uwsgi; chdir manually in this subshell
-		cd code/api
-
-		# Run
-		set +e
-
-		# Load user(s)
-		./bootstrap.py dbinit -j ../../${_folder_templates}/bootstrap.json "${_mongo_uri}"
-		result=$?
-
-		# Shut down reflex, if bootstrapping failed exit.
-		if [ $result -ne 0 ]; then
-			bb-log-info "Bootstrapping users failed. Cleaning up..."
-			StopReflex
-			exit $result;
-		fi
-
-		bb-log-info "Loading example dataset..."
-
-		# Load data
-		# TODO: change to uri
-		./bootstrap.py sort -q mongodb://localhost:${_mongo_port}/scitran $temp ../../persistent/data
-		result=$?
-
-		rm -rf $temp
-
-		if [ $result -ne 0 ]; then
-			bb-log-info "Bootstrapping data failed. Cleaning up..."
-			StopReflex
-			exit $result;
-		else
-			bb-log-info "Finishing bootstrap..."
-			StopReflex
-		fi
+		bb-log-info "Finishing bootstrap..."
+		StopReflex
 	)
 )}
 

--- a/scripts/3-targets.sh
+++ b/scripts/3-targets.sh
@@ -27,13 +27,68 @@ function Install() {
 	EnsureClientCertificates
 }
 
-# Scitran-specific environment, code, example dataset
+# Scitran-specific stateful setup
 # Will temporarily launch platform for bootstrapping purposes
 function Configure() {
+	bb-log-info "Configuring"
 
-	# Scitran-specific stateful setup
-	EnsureTestData
-	EnsureBootstrapData
+	bb-log-info "Preparing infrastructre for bootstrap..."
+	StartReflex
+
+	echo
+	echo "You probably want to add an initial superuser account to login."
+	echo "This will let you into the system and add more users."
+	echo
+
+	while true; do
+		read -p "Would you like to load a superuser account? [y/n] " yn
+		case $yn in
+			[Yy]* ) go=true;  break;;
+			[Nn]* ) go=false; break;;
+			* ) echo "Please answer yes or no.";;
+		esac
+	done
+
+	if $go; then
+		echo
+		echo "This account's email address needs to be an email that can be used to login with google."
+		echo "For example, a gmail account."
+		echo
+
+		read -p "Enter your email address: " email
+		read -p "Enter your first name: " fname
+		read -p "Enter your last name: " lname
+		echo
+
+		# Simple alternative to more mustache templating
+		temp="$( bb-tmp-file )"
+		cat templates/bootstrap.json | sed "s/your_address@email.com/$email/g" | sed "s/YourFirstName/$fname/g" | sed "s/YourLastName/$lname/g" > $temp
+
+		BootStrapUsers $temp
+	fi
+
+	echo
+	echo "You probably want to load an initial dataset to view & manage."
+	echo "This will make it easier to understand how scitran works.."
+	echo
+
+	while true; do
+		read -p "Would you like to load an initial dataset to view? [y/n] " yn
+		case $yn in
+			[Yy]* ) go=true;  break;;
+			[Nn]* ) go=false; break;;
+			* ) echo "Please answer yes or no.";;
+		esac
+	done
+	echo
+
+	if $go; then
+		EnsureTestData
+		BootStrapData
+	fi
+
+	bb-log-info "Finishing bootstrap..."
+	StopReflex
 }
 
 
@@ -66,11 +121,6 @@ function RunTarget() {
 	bb-log-info "Preparing environment"
 	Setup
 	Install
-	Configure
-
-	# Pylint has many complaints ATM; reconcile as separate project
-	# bb-log-info "Checking server code"
-	# PylintCritical code/api/
 
 	# Run
 	# Hackaround: control-C doesn't show reflex cleanup ops.
@@ -92,7 +142,10 @@ function PrintSecret() {
 function CiTarget() {
 	Setup
 	Install
-	Configure
+
+	# No-prompt varient of configure target
+	EnsureTestData
+	EnsureBootstrapData
 }
 
 function Release() {

--- a/scripts/3-targets.sh
+++ b/scripts/3-targets.sh
@@ -22,22 +22,47 @@ function Install() {
 	EnsureMongoDb
 	EnsureGolang
 	EnsureReflex
+	EnsureTemplates
+	EnsureCode
+	EnsureClientCertificates
 }
 
 # Scitran-specific environment, code, example dataset
 # Will temporarily launch platform for bootstrapping purposes
 function Configure() {
-	EnsureTemplates
-	EnsureCode
-	EnsureTestData
 
 	# Scitran-specific stateful setup
-	EnsureClientCertificates
+	EnsureTestData
 	EnsureBootstrapData
 }
 
+
+# No-prompt initial setup
+function SetupTarget() {
+	Setup
+	Install
+
+	bb-log-info "Your shared secret is: ${_auth_shared_secret}"
+
+	echo
+	echo "Setup complete! You should now edit config.toml to configure your instance."
+	echo "After that, continue with: ./live.sh configure"
+	echo
+}
+
+function ConfigureTarget() {
+	Setup
+	Install
+	Configure
+
+	echo
+	echo "You are now ready to launch scitran!"
+	echo "Try it out with: ./live.sh run"
+	echo
+}
+
 # Default: run the platform
-function Launch() {
+function RunTarget() {
 	bb-log-info "Preparing environment"
 	Setup
 	Install
@@ -64,7 +89,7 @@ function PrintSecret() {
 }
 
 # What should our CI target run?
-function CI() {
+function CiTarget() {
 	Setup
 	Install
 	Configure

--- a/templates/bootstrap.json
+++ b/templates/bootstrap.json
@@ -20,11 +20,5 @@
 			"root": true,
 			"wheel": true
 		}
-	],
-	"drones": [
-		{
-			"_id": "local",
-			"type": "engine"
-		}
 	]
 }

--- a/templates/config.toml
+++ b/templates/config.toml
@@ -20,7 +20,7 @@
 
 	# Insecure mode allows manual override by setting ?user=USER in api calls.
 	# For debugging purposes only.
-	insecure = true
+	insecure = false
 
 [ports]
 	# The port that will serve on HTTP and redirect to HTTPS.


### PR DESCRIPTION
From earlier conversation: 

* No-arg launch target will now be an explicit run target; no-arg will print usage.

* The setup target will carry out its current functions, minus the bootstrapping. No prompts; will print shared secret and now-configure blurb.

* Add configure target. If arg passed, is CSV; consume. If not, prompt for 1 user. Bootstrap.

This PR does everything sans the CSV consumption, which I'll leave for another day. Saved as #50.

---

It is now possible to boot a new instance without any users or data, which is easier for new production rollouts. Initial steps are separated into a non-prompting `./live.sh setup` portion and an interactive `./live.sh configure` portion. Documentation updated to reflect this.

Pinging @gsfr for review.