### PR TITLE
Adds the persistent dir in which the symlink will be created.

### DIFF
--- a/scripts/vagrant-every.sh
+++ b/scripts/vagrant-every.sh
@@ -6,6 +6,7 @@
 
 # Mongo does not like trying to memory-map files across operating systems.
 # Place the persistent folder on the vagrant host.
+persistentDir="/scitran/persistent"
 mongoDir="/scitran/persistent/mongo"
 mongoVDir="/scitran-mongo"
 
@@ -16,6 +17,7 @@ if [ ! -L $mongoDir ]; then
   rm -rf $mongoDir 2>1 > /dev/null || rmdir $mongoDir
 
   # Place mongo data inside the vagrant (outside the mount)
+  mkdir -p $persistentDir
   mkdir -p $mongoVDir
   ln -s $mongoVDir $mongoDir
 fi


### PR DESCRIPTION
Does what it says on the tin. Was getting the following error when provisioning a Vagrant VM from scratch.

```
==> default: ln: failed to create symbolic link ‘/scitran/persistent/mongo’: No such file or directory
```

`/scitran/persistent didn't exist, so it couldn't create the link.