### PR TITLE
Install script cleanup

### DIFF
--- a/scripts/1-install.sh
+++ b/scripts/1-install.sh
@@ -134,7 +134,6 @@ function EnsureCode() {(
 	}
 
 	EnsureClone code/api      master   https://github.com/scitran/api.git
-	EnsureClone code/www      master   https://github.com/scitran/sdm.git
 	EnsureClone code/data     master   https://github.com/scitran/data.git
 	EnsureClone code/apps     master   https://github.com/scitran/apps.git
 	EnsureClone code/www      master   https://github.com/scitran/sdm.git

--- a/scripts/1-install.sh
+++ b/scripts/1-install.sh
@@ -130,7 +130,7 @@ function EnsureTemplates() {(
 function EnsureCode() {(
 	# Folder, ref, URI
 	function EnsureClone() {
-		test -d $1 || git clone -b $2 $3 $1
+		(test -d $1 || test -L $1) || git clone -b $2 $3 $1
 	}
 
 	EnsureClone code/api      master   https://github.com/scitran/api.git

--- a/scripts/1-install.sh
+++ b/scripts/1-install.sh
@@ -134,8 +134,8 @@ function EnsureCode() {(
 	}
 
 	EnsureClone code/api      master   https://github.com/scitran/api.git
-	EnsureClone code/data     master   https://github.com/scitran/data.git
 	EnsureClone code/apps     master   https://github.com/scitran/apps.git
+	EnsureClone code/data     master   https://github.com/scitran/data.git
 	EnsureClone code/www      master   https://github.com/scitran/sdm.git
 
 	# EnsureClone code/engine   stopgapp https://github.com/scitran/engine.git


### PR DESCRIPTION
- Removed a duplicate line that ensured the `code/www` directory exists.
- Updated the `EnsureClone` function to accept a directory or symlink.