### PR TITLE
Live reload and clean shutdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,13 +47,6 @@ Check out your new local instance at [https://localhost:8443](https://localhost:
 
 This script will start everything it needs (nginx, mongo, uwsgi) and run them until you quit (Control-C).
 
-### Managing processes
-
-Right now, uwsgi is sometimes poorly behaved, and remains running after quitting the script.
-
-You can remediate this manually with `killall -9 uwsgi`.<br>
-We will correct this problem soon.
-
 ## Configuring
 
 The first setup will create a config.toml file for you from this [template](templates/config.toml).<br>

--- a/scripts/2-run.sh
+++ b/scripts/2-run.sh
@@ -14,18 +14,32 @@ function Reflex() {(
 	export PYTHONPATH=../data
 
 
+	# Run when shutting down
 	control_c() {
-		echo -en "\n*** Ouch! Exiting ***\n"
-		exit $?
+		# Complete unconditionally; wait will sometimes return 141
+		set +e
+
+		# Jump past emulator-visible "^C" text
+		echo
+		bb-log-info "Shutting down..."
+
+		# Send SIGTERM to process manager; wait for clean shutdown
+		kill $reflexPID
+		wait $reflexPID
+
+		bb-log-info "Stopped."
+		exit 0
 	}
 
 	# trap keyboard interrupt (control-c)
 	trap control_c SIGINT
 
-	# Supress reflex output decoration and uwsgi's launch message
-	$reflexLoc --decoration=plain --config=${_folder_generated}/reflex.config.sh \
-		| sed -e 's/^\[00\]/Python:  /g; s/^\[01\]/Mongo:   /g; s/^\[02\]/Nginx:   /g; /\[uWSGI\] getting INI configuration from/d; s/Starting service$/Running/; s/Killing service$/Stopping/; '
-
+	# Run reflex.
+	#
+	# Sed filter goes in a subshell to change the launch order of the two commands.
+	# This allows reflex to launch last, and get reflex's PID on the next line with $!.
+	# Capturing the PID allows us to guarantee cleanup in the control_c function.
+	#
 	# Sed statement does the following, in order:
 	# 	Labels reflex's [00] prefix as Python
 	# 	Labels reflex's [01] prefix as Mongo
@@ -33,6 +47,12 @@ function Reflex() {(
 	# 	Removes useless message from python about loading config
 	# 	Renames 'Starting service'
 	# 	Renames 'Killing service'
+	$reflexLoc --decoration=plain --config=${_folder_generated}/reflex.config.sh > >(sed -e 's/^\[00\]/Python:  /g; s/^\[01\]/Mongo:   /g; s/^\[02\]/Nginx:   /g; /\[uWSGI\] getting INI configuration from/d; s/Starting service$/Running/; s/Killing service$/Restarting.../; ') &
+
+
+	# Block here until Ctrl-C
+	reflexPID=$!
+	wait $reflexPID
 )}
 
 # This duration needs to be long enough to run and cleanly shut down all infra.

--- a/scripts/2-run.sh
+++ b/scripts/2-run.sh
@@ -13,8 +13,26 @@ function Reflex() {(
 	# Hackaround for API import problems
 	export PYTHONPATH=../data
 
+
+	control_c() {
+		echo -en "\n*** Ouch! Exiting ***\n"
+		exit $?
+	}
+
+	# trap keyboard interrupt (control-c)
+	trap control_c SIGINT
+
 	# Supress reflex output decoration and uwsgi's launch message
-	$reflexLoc --decoration=plain --config=${_folder_generated}/reflex.config.sh | grep -v "getting INI configuration from ${_folder_generated}/uwsgi.config.ini"
+	$reflexLoc --decoration=plain --config=${_folder_generated}/reflex.config.sh \
+		| sed -e 's/^\[00\]/Python:  /g; s/^\[01\]/Mongo:   /g; s/^\[02\]/Nginx:   /g; /\[uWSGI\] getting INI configuration from/d; s/Starting service$/Running/; s/Killing service$/Stopping/; '
+
+	# Sed statement does the following, in order:
+	# 	Labels reflex's [00] prefix as Python
+	# 	Labels reflex's [01] prefix as Mongo
+	# 	Labels reflex's [02] prefix as Nginx
+	# 	Removes useless message from python about loading config
+	# 	Renames 'Starting service'
+	# 	Renames 'Killing service'
 )}
 
 # This duration needs to be long enough to run and cleanly shut down all infra.

--- a/scripts/3-targets.sh
+++ b/scripts/3-targets.sh
@@ -123,13 +123,8 @@ function RunTarget() {
 	Install
 
 	# Run
-	# Hackaround: control-C doesn't show reflex cleanup ops.
-	# Should instead use a sigtrap, kill -INT, pid-wait.
 	bb-log-info "Launching"
 	Reflex
-
-	# Wait for exit
-	bb-log-info "Stopped."
 }
 
 # Print the shared secret

--- a/templates/reflex.config.sh
+++ b/templates/reflex.config.sh
@@ -5,10 +5,11 @@
 # This file is auto-generated.
 # Be sure you are editing the copy in templates/.
 
-# Python server
-# Trickery: actually just launch and never re-launch; send signals instead with next rule!
+# Some service actually just launch and never re-launch.
 # Uses reflex as an utterly simple daemon manager for development simplicity.
---start-service --glob="does-not-exist" --inverse-regex=".*" -- uwsgi {{folder.generated}}/uwsgi.config.ini
+
+# Python server
+--start-service --regex='.*\.py$' --inverse-regex="persistent/.*" -- uwsgi {{folder.generated}}/uwsgi.config.ini
 
 # Mongo server
 --start-service --glob="does-not-exist" --inverse-regex=".*" -- mongod --config {{folder.generated}}/mongo.config.yaml
@@ -18,4 +19,4 @@
 
 # Gracefully reload uwsgi on file change
 # Pidfile also used in uwsgi.config.ini
---regex='.*\.py$' --inverse-regex="persistent/.*" -- bash -c "kill -HUP `cat {{folder.pids}}/uwsgi.pid`"
+# --regex='.*\.py$' --inverse-regex="persistent/.*" -- bash -c "kill -HUP `cat {{folder.pids}}/uwsgi.pid`"


### PR DESCRIPTION
A few changes to the run target I think you'll like:

* Running services are now identified by their name, not index
* Python live-reload is handled by cycling uwsgi, not their useless "graceful reload" sig handler
* Ctrl-C is caught & reflex is cleaned up when exiting
* Hung processes should be a thing of the past

Previously:

```bash
Flywheel: Preparing environment
Flywheel: Launching
[00] Starting service
[01] Starting service
[02] Starting service

# No output when python is reloaded!
# Python reload takes arbitrarily long time!

^C

# Hanging uwsgi processes!
```

Now:

```bash
Flywheel: Preparing environment
Flywheel: Launching
Python:   Running
Mongo:    Running
Nginx:    Running
Python:   Restarting...
Python:   Sending SIGINT signal...
Python:   Sending SIGKILL signal...
Python:   Running
^C
Flywheel: Shutting down...
Flywheel: Stopped.
```

Closes #33 and #34.