### PR TITLE
Fix pythonpath problem caused by api refactor

### DIFF
--- a/live.sh
+++ b/live.sh
@@ -60,7 +60,7 @@
 				cmd="$@"
 
 				# Run command from correct directory and with workaround for API import problems
-				cmd="cd code/api; export PYTHONPATH=../data; $cmd"
+				cmd="cd code/api; export PYTHONPATH=.:../data; $cmd"
 
 				./live.sh cmd $cmd;;
 

--- a/scripts/2-run.sh
+++ b/scripts/2-run.sh
@@ -11,7 +11,7 @@ function Reflex() {(
 	LoadVenv
 
 	# Hackaround for API import problems
-	export PYTHONPATH=../data
+	export PYTHONPATH=.:../data
 
 
 	# Run when shutting down
@@ -65,7 +65,7 @@ function StartReflex() {
 	LoadVenv
 
 	# Hackaround for API import problems
-	export PYTHONPATH=../data
+	export PYTHONPATH=.:../data
 
 	# Supress reflex output decoration and uwsgi's launch message
 	# Launch reflex in the background. Omits the grep to get PID easily -.-


### PR DESCRIPTION
The `./live.sh ci` target fails locally:

```
Traceback (most recent call last):
  File "./bin/bootstrap.py", line 14, in <module>
    from api import util  # from scitran.api import util
ImportError: No module named api
```

At fault is our new API organization and the [current way we set our pythonpath](https://github.com/scitran/scitran/blob/fbdaac6b6b47e6a6e3114d1c63d516fa73b92bdf/live.sh#L63). 
For now, I added both paths as per the [pythonpath docs](https://docs.python.org/2/using/cmdline.html#envvar-PYTHONPATH).

Pinging @Eric89GXL for sanity check.