### PR TITLE
change configure target to bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ If desired, you can edit your config file now, or you can come back later. Check
 Finish your install with:
 
 ```bash
-./live.sh configure
+./live.sh bootstrap
 ```
 
 This will prepare a user account and an example dataset to try out.
@@ -37,7 +37,7 @@ From the scitran folder, simply run `vagrant up && vagrant ssh`, then use the sa
 
 ## Running
 
-Once you have setup and configured scitran, running is as easy as:
+Once you have setup and bootstrapped scitran, running is as easy as:
 
 ```bash
 ./live.sh run

--- a/live.sh
+++ b/live.sh
@@ -18,7 +18,7 @@
 	source scripts/3-targets.sh
 
 	function Usage() {
-		echo "Usage: $0 {setup|configure|run|cmd|api|http|mongo|tail-python|template|ci|release|update|secret|reset-db|lint}" 1>&2;
+		echo "Usage: $0 {setup|bootstrap|run|cmd|api|http|mongo|tail-python|template|ci|release|update|secret|reset-db|lint}" 1>&2;
 		exit 1
 	}
 
@@ -32,8 +32,8 @@
 			setup)
 				SetupTarget ;;
 
-			configure)
-				ConfigureTarget ;;
+			bootstrap)
+				BootstrapTarget ;;
 
 			run)
 				RunTarget ;;
@@ -122,10 +122,10 @@
 				PrintSecret ;;
 
 			reset-db)
-				rm -rf persistent/mongo/*
+				rm -rf persistent/mongo persistent/data
 				Setup
 				Install
-				Configure ;;
+				Bootstrap ;;
 
 			lint)
 				PyLint ;;

--- a/live.sh
+++ b/live.sh
@@ -122,7 +122,7 @@
 				PrintSecret ;;
 
 			reset-db)
-				rm -rf persistent/mongo persistent/data
+				rm -rf persistent/mongo/* persistent/data/*
 				Setup
 				Install
 				Bootstrap ;;

--- a/scripts/2-run.sh
+++ b/scripts/2-run.sh
@@ -96,7 +96,7 @@ function BootStrapUsers() {(
 
 	# Load user(s)
 	export PYTHONPATH=.:../data
-	./bin/bootstrap.py dbinit -j $1 "mongodb://${_mongo_uri}"
+	./bin/bootstrap.py users "mongodb://${_mongo_uri}" $1
 	result=$?
 
 	# Shut down reflex, if bootstrapping failed exit.

--- a/scripts/3-targets.sh
+++ b/scripts/3-targets.sh
@@ -30,8 +30,8 @@ function Install() {
 
 # Scitran-specific stateful setup
 # Will temporarily launch platform for bootstrapping purposes
-function Configure() {
-	bb-log-info "Configuring"
+function Bootstrap() {
+	bb-log-info "Bootstrapping users and test data"
 
 	bb-log-info "Preparing infrastructre for bootstrap..."
 	StartReflex
@@ -102,14 +102,14 @@ function SetupTarget() {
 
 	echo
 	echo "Setup complete! You should now edit config.toml to configure your instance."
-	echo "After that, continue with: ./live.sh configure"
+	echo "After that, continue with: ./live.sh bootstrap and or ./live.sh run"
 	echo
 }
 
-function ConfigureTarget() {
+function BootstrapTarget() {
 	Setup
 	Install
-	Configure
+	Bootstrap
 
 	echo
 	echo "You are now ready to launch scitran!"
@@ -139,7 +139,7 @@ function CiTarget() {
 	Setup
 	Install
 
-	# No-prompt varient of configure target
+	# No-prompt varient of bootstrap target
 	EnsureTestData
 	EnsureBootstrapData
 


### PR DESCRIPTION
Bootstrapping is now optional, but still highly advised.

CI expected to fail until scitran/api#42 lands.